### PR TITLE
Add tfsec to validate workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,5 +36,3 @@ jobs:
           done
       - name: tfsec
         uses: triat/terraform-security-scan@v2.1.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,8 +8,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 100
-
-      - uses: hashicorp/setup-terraform@v1
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: "~> 0.13.0"
       - name: Terraform fmt
@@ -34,3 +34,7 @@ jobs:
             printf "Operating on \"${i%%/}\"\n"
             TFLINT_PLUGIN_DIR=${{ github.workspace }}/.tflint.d/plugins tflint --loglevel=info ${i%%/}
           done
+      - name: tfsec
+        uses: triat/terraform-security-scan@v2.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Here's what I learned about `tfsec`:
* it only scans the current directory - the option to recursively scan subdirectories was removed recently
* if the working directory is not `terraform init`ed, all the external submodules, ie. submodules which aren't sourced locally (in our case from the same repository) won't be scanned => we should `init` first because we heavily rely on 3rd party modules

To keep things simple and clean, I decided to stick with the existing Github Action at https://github.com/triat/terraform-security-scan and use it to `tfsec` repository root which is `init`ed in a previous CI step. Obviously the root module calling this module should also be `tfsec`ed for all this to make sense. And then `tfsec`ing examples seems unnecessary.  

I also tested action's feature to comment on PRs if `tfsec` check fails, but decided not to use it in CI config since it works only if the event which triggers the pipeline is `pull_request` as seen [here](https://github.com/triat/terraform-security-scan/blob/aac94abfb09af48564bd95a5409d1ced4342d569/entrypoint.sh#L41). This would mean that in order for this to work we would need to change our config since actions are currently triggered on `push` events, which is the way I think it should stay. Eg. adding pull_request to list of triggers (`on: [push, pull_request]`) would have a result that each push to a branch which is a part of PR, the workflow would be executed twice which doesn't make much sense.

Additional note: adding tfsec step significantly extended time needed for the validate workflow, which now lasts ~3x times longer than before (~1.5min vs 0.5min). Although the `tfsec` operation itself is fast, this slowdown mostly due to the `go get` based `tfsec` installation for each action run. If this is a problem, alternative would be to write our own action using the official tfsec container image.

tfsec on the repo root:
![image](https://user-images.githubusercontent.com/78267893/110694871-7e399c80-81e9-11eb-8cd4-f4bac6670991.png)

tfsec step length:
![image](https://user-images.githubusercontent.com/78267893/110695203-dcff1600-81e9-11eb-9bca-14ea8abbc22f.png)

Closes 